### PR TITLE
Fixes of concurrency problems and changing FhirContext handling

### DIFF
--- a/src/main/java/de/gematik/demis/validationservice/AppConfig.java
+++ b/src/main/java/de/gematik/demis/validationservice/AppConfig.java
@@ -16,36 +16,32 @@
  *
  */
 
-package de.gematik.demis.validationservice.services;
+package de.gematik.demis.validationservice;
+
+import static de.gematik.demis.validationservice.util.LocaleUtil.withDefaultLocale;
 
 import ca.uhn.fhir.context.FhirContext;
 import java.util.Locale;
 import org.apache.commons.lang3.LocaleUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
-/**
- * Service that holds the R4 FHIR context as singleton, so that there is only one in the
- * application.
- */
-@Service
-public class FhirContextService {
-  private final FhirContext fhirContext;
-  private final Locale configuredLocale;
+@Configuration
+public class AppConfig {
 
-  public FhirContextService(@Value("${demis.validation-service.locale}") String locale) {
-    configuredLocale = LocaleUtils.toLocale(locale);
-    Locale oldLocale = Locale.getDefault();
-    Locale.setDefault(configuredLocale);
-    fhirContext = FhirContext.forR4();
-    Locale.setDefault(oldLocale); // Put back global default locale to avoid side effects
+  public static final String CONFIGURED_LOCALE_NAME = "demis.configuredLocale";
+
+  @Bean
+  public FhirContext createFhirContext(
+      @Autowired @Qualifier(CONFIGURED_LOCALE_NAME) Locale configuredLocale) {
+    return withDefaultLocale(configuredLocale, FhirContext::forR4);
   }
 
-  public FhirContext getFhirContext() {
-    return fhirContext;
-  }
-
-  public Locale getConfiguredLocale() {
-    return configuredLocale;
+  @Bean(CONFIGURED_LOCALE_NAME)
+  public Locale configuredLocale(@Value("${demis.validation-service.locale}") String locale) {
+    return LocaleUtils.toLocale(locale);
   }
 }

--- a/src/main/java/de/gematik/demis/validationservice/services/ProfileParserService.java
+++ b/src/main/java/de/gematik/demis/validationservice/services/ProfileParserService.java
@@ -20,6 +20,7 @@ package de.gematik.demis.validationservice.services;
 
 import static java.util.function.Function.identity;
 
+import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
 import java.io.IOException;
 import java.io.InputStream;
@@ -53,13 +54,13 @@ public class ProfileParserService {
           "StructureDefinition", StructureDefinition.class,
           "ValueSet", ValueSet.class);
   private final String profileResource;
-  private final FhirContextService fhirContextService;
+  private final FhirContext fhirContext;
   private Map<Class<? extends MetadataResource>, Map<String, IBaseResource>> parsedProfile;
 
   public ProfileParserService(
-      FhirContextService fhirContextService,
+      FhirContext fhirContext,
       @Value("${demis.validation-service.profileResourcePath}") String profileResource) {
-    this.fhirContextService = fhirContextService;
+    this.fhirContext = fhirContext;
     this.profileResource = profileResource;
   }
 
@@ -92,7 +93,7 @@ public class ProfileParserService {
 
     log.info("Start parsing Profiles");
     parsedProfile = new HashMap<>();
-    IParser parser = fhirContextService.getFhirContext().newJsonParser();
+    IParser parser = fhirContext.newJsonParser();
     for (Map.Entry<String, Class<? extends MetadataResource>> profilePart :
         profileParts.entrySet()) {
       Path path = Path.of(profileResource, profilePart.getKey());

--- a/src/test/java/de/gematik/demis/validationservice/services/FhirJsonServiceTest.java
+++ b/src/test/java/de/gematik/demis/validationservice/services/FhirJsonServiceTest.java
@@ -20,6 +20,8 @@ package de.gematik.demis.validationservice.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import ca.uhn.fhir.context.FhirContext;
+import de.gematik.demis.validationservice.util.ContextUtil;
 import org.hl7.fhir.r4.model.Patient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,8 +32,8 @@ class FhirJsonServiceTest {
 
   @BeforeEach
   void setupFhirParsingService() {
-    FhirContextService fhirContextService = new FhirContextService("en_US");
-    jsonService = new FhirJsonService(fhirContextService);
+    FhirContext ctx = ContextUtil.getFhirContextEn();
+    jsonService = new FhirJsonService(ctx);
   }
 
   @Test

--- a/src/test/java/de/gematik/demis/validationservice/services/ProfileParserServiceTest.java
+++ b/src/test/java/de/gematik/demis/validationservice/services/ProfileParserServiceTest.java
@@ -20,6 +20,8 @@ package de.gematik.demis.validationservice.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import ca.uhn.fhir.context.FhirContext;
+import de.gematik.demis.validationservice.util.ContextUtil;
 import de.gematik.demis.validationservice.util.ResourceFileConstants;
 import java.util.Map;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -37,9 +39,9 @@ class ProfileParserServiceTest {
 
   @BeforeAll
   static void parseProfile() {
-    FhirContextService fhirContextService = new FhirContextService("en_US");
+    FhirContext fhirContext = ContextUtil.getFhirContextEn();
     ProfileParserService service =
-        new ProfileParserService(fhirContextService, ResourceFileConstants.PROFILE_RESOURCE_PATH);
+        new ProfileParserService(fhirContext, ResourceFileConstants.PROFILE_RESOURCE_PATH);
     parsedProfile = service.getParseProfiles();
   }
 

--- a/src/test/java/de/gematik/demis/validationservice/services/ValidationServiceTest.java
+++ b/src/test/java/de/gematik/demis/validationservice/services/ValidationServiceTest.java
@@ -21,7 +21,9 @@ package de.gematik.demis.validationservice.services;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ca.uhn.fhir.context.FhirContext;
 import de.gematik.demis.validationservice.services.validation.ValidationService;
+import de.gematik.demis.validationservice.util.ContextUtil;
 import de.gematik.demis.validationservice.util.FileTestUtil;
 import de.gematik.demis.validationservice.util.ResourceFileConstants;
 import java.io.IOException;
@@ -54,11 +56,10 @@ class ValidationServiceTest {
 
   @BeforeAll
   static void setupValidationService() {
-    FhirContextService fhirContextService = new FhirContextService(DEFAULT_LOCALE);
+    FhirContext fhirContext = ContextUtil.getFhirContextEn();
     profileParserService =
-        new ProfileParserService(fhirContextService, ResourceFileConstants.PROFILE_RESOURCE_PATH);
-    validationService =
-        new ValidationService(fhirContextService, profileParserService, "information");
+        new ProfileParserService(fhirContext, ResourceFileConstants.PROFILE_RESOURCE_PATH);
+    validationService = new ValidationService(fhirContext, profileParserService, "information");
   }
 
   @Test
@@ -140,9 +141,9 @@ class ValidationServiceTest {
   @Test
   void validateValidFileAndFilterInformationAndWarningsAndCheckThereIsOnlyOneIssue()
       throws IOException {
-    FhirContextService fhirContextService = new FhirContextService(DEFAULT_LOCALE);
+    FhirContext fhirContextEn = ContextUtil.getFhirContextEn();
     ValidationService validationServiceWithFilter =
-        new ValidationService(fhirContextService, profileParserService, "error");
+        new ValidationService(fhirContextEn, profileParserService, "error");
     String validFileContent =
         FileTestUtil.readFileIntoString(ResourceFileConstants.VALID_REPORT_BED_OCCUPANCY_EXAMPLE);
 
@@ -155,9 +156,9 @@ class ValidationServiceTest {
   @Test
   void setValidationServiceToGermanAndValidateInvalidFileAndCheckThereIsOneErrorWithAGermanAnswer()
       throws IOException {
-    FhirContextService fhirContextService = new FhirContextService("de_DE");
+    FhirContext fhirContext = ContextUtil.getFhirContextDe();
     ValidationService germanValidationService =
-        new ValidationService(fhirContextService, profileParserService, "information");
+        new ValidationService(fhirContext, profileParserService, "information");
     String invalidFileContent =
         FileTestUtil.readFileIntoString(ResourceFileConstants.INVALID_REPORT_BED_OCCUPANCY_EXAMPLE);
 

--- a/src/test/java/de/gematik/demis/validationservice/util/ContextUtil.java
+++ b/src/test/java/de/gematik/demis/validationservice/util/ContextUtil.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright [2023], gematik GmbH
+ *
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the
+ * European Commission – subsequent versions of the EUPL (the "Licence").
+ *
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either expressed or implied.
+ *
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ *
+ */
+
+package de.gematik.demis.validationservice.util;
+
+import ca.uhn.fhir.context.FhirContext;
+import de.gematik.demis.validationservice.AppConfig;
+import java.util.Locale;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class ContextUtil {
+
+  private ContextUtil() {}
+
+  private static final ConcurrentMap<Locale, FhirContext> CONTEXTS = new ConcurrentHashMap<>();
+
+  public static FhirContext getFhirContextEn() {
+    return getFhirContextForLocale(Locale.US);
+  }
+
+  public static FhirContext getFhirContextDe() {
+    return getFhirContextForLocale(Locale.GERMANY);
+  }
+
+  public static FhirContext getFhirContextForLocale(Locale locale) {
+    return CONTEXTS.computeIfAbsent(locale, ContextUtil::createContextForLocale);
+  }
+
+  private static FhirContext createContextForLocale(Locale locale) {
+    return new AppConfig().createFhirContext(locale);
+  }
+}


### PR DESCRIPTION
- JSON Parser was cached and reused in FhirJsonService, which may cause threading issues. Since parsers are cheap to create, removed caching
- Setting default locale was done in multiple places and in a potentially thread unsafe way. The code was centralized in LocaleUtil. Previous code was not unsafe though, the thread safety was just added as a precaution.
- Removed FhirContextService, as a service providing a singleton only adds overhead and is more complicated to use. The context is now created in a spring configuration, and caching of the singleton is now delegated to the Spring Boot framework.
- Fixes #3